### PR TITLE
fix_signal_blocking. 

### DIFF
--- a/src/process_utils.cpp
+++ b/src/process_utils.cpp
@@ -159,7 +159,7 @@ void reset_signals_nothrow() {
     // resume all signals
     sigset_t allmask;
     sigfillset(std::addressof(allmask));
-    int err = ::pthread_sigmask(SIG_SETMASK, std::addressof(allmask), nullptr);
+    int err = ::pthread_sigmask(SIG_UNBLOCK, std::addressof(allmask), nullptr);
     if (0 != err) {
         std::cout << 
                 TRACEMSG("Error resuming signals in child: [" + ::strerror(err) + "]") 


### PR DESCRIPTION
fixed TERM signal blocking by child vforked process.
reset_signals_nothrow() - used for reset signals, but SIG_SETMASK blocks all signals except SIGINT and SIGSTOP.
Use SIG_UNBLOCK instead.